### PR TITLE
Log errors as skipping callbacks will be deprecated soon.

### DIFF
--- a/lib/platform-mac.js
+++ b/lib/platform-mac.js
@@ -125,7 +125,9 @@ module.exports = {
       exec(`osascript ${apple_script}`, (err, stdout, stderr) => {
         if (err) return reject(check_for_missing_app_hack(err));
         if (stderr) return reject(stderr);
-        fs.unlink(apple_script);
+        fs.unlink(apple_script, function (err) {
+          if (err) console.error(err)
+        });
 
         resolve(stdout);
       });
@@ -144,7 +146,9 @@ module.exports = {
       throw check_for_missing_app_hack(err);
     }
 
-    fs.unlink(apple_script);
+    fs.unlink(apple_script, function (err) {
+      if (err) console.error(err)
+    });
   },
 
   canExecute: function(command) {

--- a/lib/platform-win.js
+++ b/lib/platform-win.js
@@ -72,7 +72,9 @@ module.exports = {
         // see * below
         //if (err) return reject(err);
         //if (stderr) return reject(stderr);
-        fs.unlink(jsx.script);
+        fs.unlink(jsx.script, function (err) {
+          if (err) console.error(err)
+        });
 
         resolve();
       });
@@ -92,7 +94,9 @@ module.exports = {
       //For now, we just ignore errors on execSync
     }
 
-    fs.unlink(jsx.script);
+    fs.unlink(jsx.script, function (err) {
+      if (err) console.error(err)
+    });
   },
 
   canExecute: function(command) {


### PR DESCRIPTION
In console you can see warnings, as you are not providing callbacks. This will log that error messages. If there is something better you can suggest, I'm agree to change this code. This was just quick fix.