### PR TITLE
Fix AppleScript escaping

### DIFF
--- a/lib/platform-mac.js
+++ b/lib/platform-mac.js
@@ -5,7 +5,7 @@ const fs = 		 require('fs'),
       path =   require('path'),
       uuid =   require('uuid'),
       os =     require('os'),
-      esc =    require('jsesc');
+      esc =    require('escape-string-applescript');
 
 const exec =      child.exec,
       execSync =  child.execSync;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "after-effects",
-  "version": "0.4.11",
+  "version": "0.4.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -621,6 +621,11 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "escape-string-applescript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-applescript/-/escape-string-applescript-2.0.0.tgz",
+      "integrity": "sha1-dgvKg4Zo5Aj+XuUs5CyvfLRsUnM="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "babel-plugin-transform-es3-property-literals": "^6.8.0",
     "babel-plugin-transform-es5-property-mutators": "^6.8.0",
     "babel-preset-es2015": "^6.3.13",
+    "escape-string-applescript": "^2.0.0",
     "is-explicit": "^1.2.2",
-    "jsesc": "^1.2.0",
     "uglify-js": "^2.6.2",
     "uuid": "^2.0.1"
   }


### PR DESCRIPTION
Running the generated AppleScript fails because it's not escaped correctly. Fixed by using the escape-string-applescript package instead of jsesc.